### PR TITLE
[cmake] Allow using standalone toolchain

### DIFF
--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -377,11 +377,7 @@ endif()
 get_filename_component(ANDROID_NDK ${CMAKE_CURRENT_LIST_DIR} DIRECTORY)
 
 # remember found paths
-if( ANDROID_NDK )
- get_filename_component( ANDROID_NDK "${ANDROID_NDK}" ABSOLUTE )
- set( ANDROID_NDK "${ANDROID_NDK}" CACHE INTERNAL "Path of the Android NDK" FORCE )
- set( BUILD_WITH_ANDROID_NDK True )
-elseif( ANDROID_STANDALONE_TOOLCHAIN )
+if( ANDROID_STANDALONE_TOOLCHAIN )
  get_filename_component( ANDROID_STANDALONE_TOOLCHAIN "${ANDROID_STANDALONE_TOOLCHAIN}" ABSOLUTE )
  # try to detect change
  if( CMAKE_AR )
@@ -395,6 +391,10 @@ elseif( ANDROID_STANDALONE_TOOLCHAIN )
  endif()
  set( ANDROID_STANDALONE_TOOLCHAIN "${ANDROID_STANDALONE_TOOLCHAIN}" CACHE INTERNAL "Path of the Android standalone toolchain" FORCE )
  set( BUILD_WITH_STANDALONE_TOOLCHAIN True )
+elseif( ANDROID_NDK )
+ get_filename_component( ANDROID_NDK "${ANDROID_NDK}" ABSOLUTE )
+ set( ANDROID_NDK "${ANDROID_NDK}" CACHE INTERNAL "Path of the Android NDK" FORCE )
+ set( BUILD_WITH_ANDROID_NDK True )
 else()
  message( FATAL_ERROR "Could not find neither Android NDK nor Android standalone toolchain.
     You should set an environment variable:


### PR DESCRIPTION
Because ANDROID_NDK is always defined in this script, the
ANDROID_STANDALONE_TOOLCHAIN case is never checked. Inverting the if
cases fixes this and allows using toolchains generated with
`build/tools/make-standalone-toolchain.sh`