### PR TITLE
Fix build error on x86_64 with non-binary shell

### DIFF
--- a/build/tools/ndk-common.sh
+++ b/build/tools/ndk-common.sh
@@ -289,7 +289,7 @@ case "$HOST_OS-$HOST_ARCH" in
         SYSTEM_FILE_PROGRAM="/usr/bin/file"
         test -x "$SYSTEM_FILE_PROGRAM" && HOST_FILE_PROGRAM="$SYSTEM_FILE_PROGRAM"
     fi
-    "$HOST_FILE_PROGRAM" -L "$SHELL" | grep -q "x86[_-]64"
+    "$HOST_FILE_PROGRAM" -L "/bin/sh" | grep -q "x86[_-]64"
     if [ $? != 0 ]; then
       # $SHELL is not a 64-bit executable, so assume our userland is too.
       log "Detected 32-bit userland on 64-bit kernel system!"


### PR DESCRIPTION
Build fails on x86_64 with a non-binary shell (such as the excellent xonsh Python-based shell) because `$SHELL` wouldn't give information about the userspace architecture (instead, I get `/usr/bin/xonsh: Python script, UTF-8 Unicode text executable`). I propose to simply check `/bin/sh` instead which is fairly guaranteed to be a binary.